### PR TITLE
Add initial drop of non-default Leap 16 wallpapers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,15 @@ install:
 				png_file=${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/`basename $${svg} .svg`.png; \
 				rsvg-convert $${svg} -o $${png_file}; \
 				optipng -o2 $${png_file}; \
-				install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
 			done; \
 		fi; \
-		install -D -m 0644 $${dir}/*.jpg ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
-		install -D -m 0644 $${dir}/*.xml ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+		if ls $${dir}/*.jpg >/dev/null 2>&1; then \
+			install -D -m 0644 $${dir}/*.jpg ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+		fi; \
+		if ls $${dir}/*.xml >/dev/null 2>&1; then \
+			install -D -m 0644 $${dir}/*.xml ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+		fi; \
+		if ls $${dir}/*.png >/dev/null 2>&1; then \
+			install -D -m 0644 $${dir}/*.png ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+		fi; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
-install: 
-	mkdir -p /usr/share/gnome-background-properties/
-	install -D -m 0644 wallpapers-leap15.xml ${DESTDIR}/usr/share/gnome-background-properties/wallpapers-leap15.xml
-	mkdir -p /usr/share/wallpapers/leap15/
-	install -D -m 0644 leap15/*.jpg ${DESTDIR}/usr/share/wallpapers/leap15/
-	install -D -m 0644 leap15/*.xml ${DESTDIR}/usr/share/wallpapers/leap15/
+VERSION = 16
+SVG_FILES = $(wildcard leap$(VERSION)/*.svg)
+
+install:
+	mkdir -p ${DESTDIR}/usr/share/gnome-background-properties/
+	install -D -m 0644 wallpapers-leap${VERSION}.xml ${DESTDIR}/usr/share/gnome-background-properties/wallpapers-leap${VERSION}.xml
+	mkdir -p ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/
+    
+	# Convert SVG files to PNG and optimize with optipng
+	for svg in $(SVG_FILES); do \
+	    png_file=${DESTDIR}/usr/share/wallpapers/leap$(VERSION)/`basename $${svg} .svg`.png; \
+	    rsvg-convert $${svg} -o $${png_file}; \
+	    optipng -o5 $${png_file}; \
+	    install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/; \
+	done
+
+	install -D -m 0644 leap${VERSION}/*.jpg ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/
+	install -D -m 0644 leap${VERSION}/*.xml ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/
+

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,14 @@ install:
 		mkdir -p ${DESTDIR}/usr/share/gnome-background-properties/; \
 		install -D -m 0644 wallpapers-leap$${VERSION}.xml ${DESTDIR}/usr/share/gnome-background-properties/wallpapers-leap$${VERSION}.xml; \
 		mkdir -p ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
-
-		# Doing this on build time is quite expensive see gh#openSUSE/wallpapers#20
-		for svg in $${dir}/*.svg; do \
-			png_file=${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/`basename $${svg} .svg`.png; \
-			rsvg-convert $${svg} -o $${png_file}; \
-			optipng -o5 $${png_file}; \
-			install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
-		done
-
-		# Install JPG and XML files
+		if ls $${dir}/*.svg >/dev/null 2>&1; then \
+			for svg in $${dir}/*.svg; do \
+				png_file=${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/`basename $${svg} .svg`.png; \
+				rsvg-convert $${svg} -o $${png_file}; \
+				optipng -o5 $${png_file}; \
+				install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+			done; \
+		fi; \
 		install -D -m 0644 $${dir}/*.jpg ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
 		install -D -m 0644 $${dir}/*.xml ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
-VERSION = 16
-SVG_FILES = $(wildcard leap$(VERSION)/*.svg)
+LEAP_DIRS = $(wildcard leap*)
 
 install:
-	mkdir -p ${DESTDIR}/usr/share/gnome-background-properties/
-	install -D -m 0644 wallpapers-leap${VERSION}.xml ${DESTDIR}/usr/share/gnome-background-properties/wallpapers-leap${VERSION}.xml
-	mkdir -p ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/
-    
-	# Convert SVG files to PNG and optimize with optipng
-	for svg in $(SVG_FILES); do \
-	    png_file=${DESTDIR}/usr/share/wallpapers/leap$(VERSION)/`basename $${svg} .svg`.png; \
-	    rsvg-convert $${svg} -o $${png_file}; \
-	    optipng -o5 $${png_file}; \
-	    install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/; \
+	for dir in $(LEAP_DIRS); do \
+		VERSION=$$(echo $${dir} | sed 's/leap//'); \
+		mkdir -p ${DESTDIR}/usr/share/gnome-background-properties/; \
+		install -D -m 0644 wallpapers-leap$${VERSION}.xml ${DESTDIR}/usr/share/gnome-background-properties/wallpapers-leap$${VERSION}.xml; \
+		mkdir -p ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+
+		# Doing this on build time is quite expensive see gh#openSUSE/wallpapers#20
+		for svg in $${dir}/*.svg; do \
+			png_file=${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/`basename $${svg} .svg`.png; \
+			rsvg-convert $${svg} -o $${png_file}; \
+			optipng -o5 $${png_file}; \
+			install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+		done
+
+		# Install JPG and XML files
+		install -D -m 0644 $${dir}/*.jpg ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
+		install -D -m 0644 $${dir}/*.xml ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
 	done
-
-	install -D -m 0644 leap${VERSION}/*.jpg ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/
-	install -D -m 0644 leap${VERSION}/*.xml ${DESTDIR}/usr/share/wallpapers/leap${VERSION}/
-

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 			for svg in $${dir}/*.svg; do \
 				png_file=${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/`basename $${svg} .svg`.png; \
 				rsvg-convert $${svg} -o $${png_file}; \
-				optipng -o5 $${png_file}; \
+				optipng -o2 $${png_file}; \
 				install -D -m 0644 $${png_file} ${DESTDIR}/usr/share/wallpapers/leap$${VERSION}/; \
 			done; \
 		fi; \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# wallpapers
+# wallpapers-openSUSE-extra
 
-Contest is over, better luck next time :D
+Additional community wallpapers available for Leap and Tumbleweed.
+wallpapers-openSUSE-extra is suggested by [branding-openSUSE](https://github.com/openSUSE/branding) and completes the wallpaper selection
+for individual releases aside from default wallpaper.
 
-~~**openSUSE wallpaper contest**~~
+# How to build the package?
 
-~~Resolution: 4K +~~
+Package needs to be updated in [X11:common:Factory/wallpapers-openSUSE-extra](https://build.opensuse.org/package/show/X11:common:Factory/wallpapers-openSUSE-extra). And submited to openSUSE:Factory and openSUSE:Leap:16.X projects.
 
-~~License: CC allowing for commercial use (attatched in seperate TXT file)~~
+Please be aware that pngs are rendered from svgs at build time. Aside from photos we only intend to store svgs in this repository.
 
-~~Pull request welcome :D~~
+# Where are the default wallpapers?
+
+The default wallpapers are stored in release specific branch of [openSUSE/branding](https://github.com/openSUSE/branding) and built in [Base:System/branding-openSUSE](https://build.opensuse.org/package/show/Base:System/branding-openSUSE). Aditionally GNOME has dconf defaults preset in [GNOME:Factory/glib2-branding](https://build.opensuse.org/package/show/GNOME:Factory/glib2-branding). Each Window Manager might have additional metadata in respective -branding packages.

--- a/leap16/license/license_arwinneil.txt
+++ b/leap16/license/license_arwinneil.txt
@@ -1,0 +1,4 @@
+blue_tailed_day_gecko_ebony_forest_mauritius.jpg
+was released under Public Domain by Arwin Neil Baichoo
+
+https://www.inaturalist.org/photos/412551389

--- a/leap16/project.svg
+++ b/leap16/project.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="4096"
+   height="4096"
+   version="1.1"
+   viewBox="0 0 1083.7333 1083.7333"
+   id="svg2"
+   sodipodi:docname="project-square.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   inkscape:export-filename="project-square.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="0.22625"
+     inkscape:cx="1809.9448"
+     inkscape:cy="2039.779"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs2">
+    <filter
+       id="filter1414"
+       x="0"
+       y="0"
+       width="1"
+       height="1"
+       color-interpolation-filters="sRGB">
+      <feTurbulence
+         baseFrequency="1 1"
+         result="result1"
+         type="fractalNoise"
+         id="feTurbulence1" />
+      <feDisplacementMap
+         in="SourceGraphic"
+         in2="result1"
+         result="result2"
+         scale="71.492705"
+         xChannelSelector="R"
+         yChannelSelector="G"
+         id="feDisplacementMap1" />
+      <feComposite
+         in2="SourceGraphic"
+         operator="atop"
+         id="feComposite1" />
+    </filter>
+    <linearGradient
+       id="linearGradient2366"
+       x1="577.42999"
+       x2="1157.2"
+       y1="32.848"
+       y2="995.38"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#44a591"
+         offset="0"
+         id="stop1" />
+      <stop
+         stop-color="#1f473f"
+         offset="1"
+         id="stop2" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     transform="matrix(0.80057128,0,0,1.2815085,-0.39905495,-0.63879797)"
+     x="0.49847001"
+     y="0.49847001"
+     width="1353.7"
+     height="845.66998"
+     rx="0"
+     ry="0"
+     fill="url(#linearGradient2366)"
+     filter="url(#filter1414)"
+     id="rect2"
+     style="fill:url(#linearGradient2366)" />
+  <path
+     d="m 831.44645,673.88846 c 0,-10.7133 -8.68557,-19.40051 -19.40052,-19.40051 -53.57469,0 -97.00583,43.42951 -97.00583,97.00585 0,42.85942 34.74426,77.60201 77.60203,77.60201 32.14579,0 58.20154,-26.0541 58.20154,-58.20315 0,-21.42888 -17.37215,-38.80267 -38.80269,-38.80267 -10.71477,0 -19.40052,8.68773 -19.40052,19.40052 M 928.44241,538.07499 c 32.1458,0 58.20318,-26.05903 58.20318,-58.20318 0,-32.14415 -26.05738,-58.20319 -58.20318,-58.20319 -32.14579,0 -58.20318,26.05904 -58.20318,58.20319 0,32.14415 26.05739,58.20318 58.20318,58.20318 h 135.80669 v -58.20318 c 0,-67.90345 -48.5015,-135.80524 -135.80669,-135.80524 H 792.64046 v 77.60205 c -150.00709,0 -271.61373,121.60336 -271.61373,271.61375 0,128.57657 104.23286,232.80941 232.80943,232.80941 96.43409,0 174.61119,-78.1738 174.61119,-174.61116 0,-10.71312 -8.68557,-19.4005 -19.40051,-19.4005 M 792.64378,479.86027 c 0,67.90345 48.49963,135.80522 135.80357,135.80522 h 77.60155 c 10.715,0 19.4012,-8.68375 19.4012,-19.4005"
+     fill="none"
+     stroke="#ffffff"
+     stroke-dashoffset="10"
+     stroke-opacity="0.059683"
+     stroke-width="38.8604"
+     id="path2" />
+</svg>

--- a/wallpapers-leap16.xml
+++ b/wallpapers-leap16.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+	<wallpaper>
+		<name>Project gradient</name>
+		<filename>/usr/share/wallpapers/leap16/project.png</filename>
+		<options>zoom</options>
+	</wallpaper>
+	<wallpaper>
+		<name>Blue-Tailed Day Gecko in the Ebony Forest of Mauritius</name>
+		<filename>/usr/share/wallpapers/leap16/blue_tailed_day_gecko_ebony_forest_mauritius.jpg</filename>
+		<options>zoom</options>
+	</wallpaper>
+</wallpapers>


### PR DESCRIPTION
* Factory will simply use latest Leap wallpaper drop we intend to suggest package from branding-openSUSE package
* Gecko from Photo competition gh#openSUSE/wallpapers#18
* Gradient with the new lcp's project logo gh#openSUSE/branding#156
* Install also files from previous versions (will be split into subpackages in the .spec)
* Update Readme